### PR TITLE
 Fix IndexError in sortedAP() when image_average=True in Evaluator 

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -358,7 +358,7 @@ def evaluator_decorator(metric_name):
             for k, value in signature.parameters.items():
                 if k not in kwargs and value.default != inspect.Signature.empty:
                     kwargs_default[k] = value.default
-            if args[0].image_average:
+            if args[0].image_average and metric_name not in ['sortedAP']:
                 kwargs_ps = kwargs.copy()
                 if 'verbose' in kwargs_ps.keys():
                     del kwargs_ps['verbose']


### PR DESCRIPTION
This pull request fixes an IndexError that occurs when calling e_done.sortedAP() with the image_average parameter set to True. The error is triggered during the printing of the metric in the decorated function due to attempting to index a scalar variable after applying the np.mean operation.

**Problem:**: When image_average=True, the code attempts to average all metrics, including sortedAP. However, according to the paper, I believe that sortedAP should not be averaged. In this mode, the metric is calculated as the mean of individual metrics from each example. After applying np.mean, the result is a scalar value. The code then tries to index this scalar when processing the sortedAP metric, leading to the following error:
```
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
Cell In[17], line 2
      1 # aps contain pairs of (jac, ap), sorted in jac(IoU) increasing order
----> 2 scores, aps = e.sortedAP()
      4 # plot the complete AP curve
      5 aps = np.array(aps)

File G:\Documents\Github\instance_segmentation\evaluate_sortedAP.py:378, in evaluator_decorator.<locals>.decorator.<locals>.decorated(*args, **kwargs)
    376 if verbose:
    377     if metric_name in ['sortedAP']:
--> 378         print('{}: {}, image average: {}'.format(metric_name, metric[0], args[0].image_average))
    379     else:
    380         print('{}: {}, image average: {}'.format(metric_name, metric, args[0].image_average))

IndexError: invalid index to scalar variable.
```

Solution:
- Modification in the Decorator:
    1. Added sortedAP to the list of metrics that should never be averaged, ensuring it is always treated correctly.


